### PR TITLE
Update dependency-check maven version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1582,7 +1582,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.4.4</version>
+                <version>8.0.1</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>


### PR DESCRIPTION
We seem to be running into https://github.com/jeremylong/DependencyCheck/issues/5318 when running dependency check with website-docs module included. 